### PR TITLE
adding page number at the end of the API call

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -18,7 +18,7 @@ for iteration in $(seq 1 60); do
     curl --silent \
         --header "Authorization: token ${GITHUB_TOKEN}" \
         --header 'Accept: application/vnd.github.v3+json' \
-        "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/artifacts?per_page=${PAGE_SIZE}" > $TEMP_FILE;
+        "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/artifacts?per_page=${PAGE_SIZE}&page=${iteration}" > $TEMP_FILE;
     if [ $? -ne 0 ]; then
         echo "::error ::Can't get artifact list";
         exit 1;


### PR DESCRIPTION
## Context

In case a repo has a long list of artifacts, it's possible that the seached file is not within the first 100 responses of the `artifacts` API call. By setting the page number every second we retry the query we have a chance to find an artifact that was created earlier.

## Checklist
- [x] Change meets or does not compromise the Baseline Security Requirements
